### PR TITLE
Optimize FourierFilters class and update FFT functionality 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 ![Travis (.com)](https://img.shields.io/travis/com/matteo-ronchetti/torch-radon)
 [![Documentation Status](https://readthedocs.org/projects/torch-radon/badge/?version=latest)](http://torch-radon.readthedocs.io/?badge=latest)
 ![GitHub](https://img.shields.io/github/license/matteo-ronchetti/torch-radon)
-[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/10GdKHk_6346aR4jl5VjPPAod1gTEsza9)
-# TorchRadon: Fast Differentiable Routines for Computed Tomography
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1A8axh4TMn8C7v4velMgDeovncDKDUXf8?usp=sharing)
+
+
+
+# torch-radon (forked)
 
 TorchRadon is a PyTorch extension written in CUDA that implements differentiable routines
 for solving computed tomography (CT) reconstruction problems.
@@ -26,47 +29,31 @@ Implemented operations:
  - Fan Beam projections
  - Shearlet transform
  
- 
-## Installation
-Currently only Linux is supported, if you are running a different OS please use Google Colab or the Docker image.
-### Precompiled packages
-If you are running Linux you can install Torch Radon by running:
-```shell script
-wget -qO- https://raw.githubusercontent.com/matteo-ronchetti/torch-radon/master/auto_install.py  | python -
-```
+## Google Colab
 
-### Google Colab
 You can try the library from your browser using Google Colab, you can find an example
-notebook [here](https://colab.research.google.com/drive/10GdKHk_6346aR4jl5VjPPAod1gTEsza9?usp=sharing).
+notebook [here](https://colab.research.google.com/drive/1A8axh4TMn8C7v4velMgDeovncDKDUXf8?usp=sharing).
+If you are using this repository in Google Colab, follow these commands to build from source and install the modified version:
 
-### Docker Image
-Docker images with PyTorch CUDA and Torch Radon are available [here](https://hub.docker.com/repository/docker/matteoronchetti/torch-radon).
-```shell script
-docker pull matteoronchetti/torch-radon
 ```
-To use the GPU in docker you need to use [nvidia-docker](https://github.com/NVIDIA/nvidia-docker)
-
-### Build from source
-You need to have [CUDA](https://developer.nvidia.com/cuda-toolkit) and [PyTorch](https://pytorch.org/get-started/locally/) installed, then run:
-```shell script
-git clone https://github.com/matteo-ronchetti/torch-radon.git
-cd torch-radon
-python setup.py install
+!git clone https://github.com/sypsyp97/torch-radon.git
+!wget https://github.com/sypsyp97/torch-radon/raw/master/examples/phantom.npy
+%cd torch-radon
+!pip install .
+%cd ..
 ```
-If you encounter any problem please contact the author or open an issue.
 
-## Benchmarks
-The library is noticeably faster than the Astra Toolbox, especially when data is already on the GPU. Main disadvantage of Astra is that it only takes inputs which are on the CPU, this makes training end-to-end neural networks very inefficient.
-The following benchmark compares the speed of Astra Toolbox and Torch Radon:
-![V100 Benchmark](pictures/v100.png?raw=true)
+## Acknowledgement
 
-If we set `clip_to_circle=True` (consider only the part of the image that is inside the circle) the speed difference is even larger:
-![V100 Benchmark circle](pictures/v100_circle.png?raw=true)
+This is a fork of the [torch-radon](https://github.com/matteo-ronchetti/torch-radon.git) project originally created and maintained by [Matteo Ronchetti](https://github.com/matteo-ronchetti). 
 
-These results hold also on a cheap laptop GPU: 
-![GTX1650 Benchmark](pictures/gtx1650.png?raw=true)
+## TODO List
+
+- [x] `torch.rfft` and `torch.irfft` are not supported any more, move to `torch.fft.rfft` and `torch.fft.irfft`
+- [ ] Extend to Cone Beam projections
 
 ## Cite
+
 If you are using TorchRadon in your research, please cite the following paper:
 ```
 @article{torch_radon,
@@ -76,11 +63,3 @@ Year = {2020},
 Eprint = {arXiv:2009.14788},
 journal={arXiv preprint arXiv:2009.14788},
 }
-```
-
-## Testing
-Install testing dependencies with `pip install -r test_requirements.txt`
-then test with:
-```shell script
-nosetests tests/
-```

--- a/torch_radon/filtering.py
+++ b/torch_radon/filtering.py
@@ -1,5 +1,6 @@
 import numpy as np
 import torch
+from functools import lru_cache
 
 try:
     import scipy.fft
@@ -13,18 +14,15 @@ except ImportError:
 
 class FourierFilters:
     def __init__(self):
-        self.cache = dict()
+        pass
 
     def get(self, size: int, filter_name: str, device):
-        key = (size, filter_name)
-
-        if key not in self.cache:
-            ff = torch.FloatTensor(self.construct_fourier_filter(size, filter_name)).view(1, -1, 1).to(device)
-            self.cache[key] = ff
-
-        return self.cache[key].to(device)
+        filter_name = filter_name.lower()
+        ff = self.construct_fourier_filter(size, filter_name).view(1, 1, -1).to(device)
+        return ff
 
     @staticmethod
+    @lru_cache(maxsize=128)
     def construct_fourier_filter(size, filter_name):
         """Construct the Fourier filter.
 
@@ -50,34 +48,28 @@ class FourierFilters:
                Imaging", IEEE Press 1988.
 
         """
-        filter_name = filter_name.lower()
 
-        n = np.concatenate((np.arange(1, size / 2 + 1, 2, dtype=np.int),
-                            np.arange(size / 2 - 1, 0, -2, dtype=np.int)))
+        # Initial computations
+        n = np.concatenate((np.arange(1, size // 2 + 1, 2, dtype=np.int),
+                            np.arange(size // 2 - 1, 0, -2, dtype=np.int)))
         f = np.zeros(size)
         f[0] = 0.25
         f[1::2] = -1 / (np.pi * n) ** 2
-
-        # Computing the ramp filter from the fourier transform of its
-        # frequency domain representation lessens artifacts and removes a
-        # small bias as explained in [1], Chap 3. Equation 61
         fourier_filter = 2 * np.real(fftmodule.fft(f))  # ramp filter
-        if filter_name == "ramp" or filter_name == "ram-lak":
-            pass
-        elif filter_name == "shepp-logan":
-            # Start from first element to avoid divide by zero
-            omega = np.pi * fftmodule.fftfreq(size)[1:]
-            fourier_filter[1:] *= np.sin(omega) / omega
-        elif filter_name == "cosine":
-            freq = np.linspace(0, np.pi, size, endpoint=False)
-            cosine_filter = fftmodule.fftshift(np.sin(freq))
-            fourier_filter *= cosine_filter
-        elif filter_name == "hamming":
-            fourier_filter *= fftmodule.fftshift(np.hamming(size))
-        elif filter_name == "hann":
-            fourier_filter *= fftmodule.fftshift(np.hanning(size))
-        else:
-            print(
-                f"[TorchRadon] Error, unknown filter type '{filter_name}', available filters are: 'ramp', 'shepp-logan', 'cosine', 'hamming', 'hann'")
 
-        return fourier_filter
+        # Frequency domain filter adjustments
+        filter_functions = {
+            "ramp": lambda x: x,
+            "ram-lak": lambda x: x,
+            "shepp-logan": lambda x: x[1:] * np.sin(np.pi * fftmodule.fftfreq(size)[1:]) / np.pi * fftmodule.fftfreq(size)[1:],
+            "cosine": lambda x: x * fftmodule.fftshift(np.sin(np.linspace(0, np.pi, size, endpoint=False))),
+            "hamming": lambda x: x * fftmodule.fftshift(np.hamming(size)),
+            "hann": lambda x: x * fftmodule.fftshift(np.hanning(size))
+        }
+        if filter_name not in filter_functions:
+            raise ValueError(f"[TorchRadon] Error, unknown filter type '{filter_name}', available filters are: 'ramp', 'shepp-logan', 'cosine', 'hamming', 'hann'")
+        
+        fourier_filter = filter_functions[filter_name](fourier_filter)
+
+        # Return the first n//2 + 1 elements to match the output of rfft
+        return torch.FloatTensor(fourier_filter[:size//2 + 1])


### PR DESCRIPTION
Hi @matteo-ronchetti,

This PR includes two main updates to the `torch_radon` package:

1. `torch.rfft` and `torch.irfft` used to filter the sinogram are not supported by PyTorch anymore. This has been updated to use the `torch.fft.rfft` and `torch.fft.irfft`, making `torch_radon` compatible with PyTorch 2.0.

2. `FourierFilters` class has been optimized for better error handling and efficiency. 

I believe these updates will enhance the user experience of the `torch_radon` package. Looking forward to your feedback.

Best,
Yipeng

